### PR TITLE
Add a pags attribute tester : MissingTester

### DIFF
--- a/uportal-war/src/main/java/org/fr/runn/groups/pags/testers/MissingTester.java
+++ b/uportal-war/src/main/java/org/fr/runn/groups/pags/testers/MissingTester.java
@@ -1,0 +1,26 @@
+package fr.runn.groups.pags.testers;
+
+import org.jasig.portal.groups.pags.testers.BaseAttributeTester;
+import org.jasig.portal.security.IPerson;
+
+/**
+ * Tests whether the attribute is null 
+ */
+public class MissingTester extends BaseAttributeTester {
+
+    public MissingTester(String attribute, String test) {
+        super(attribute, test);
+    }
+
+    public boolean test(IPerson person) {
+        // Get the list of values for the attribute
+        Object[] vals = person.getAttributeValues(getAttributeName());
+
+        // No values, test passed
+        if (vals == null || vals.length == 0 || (vals.length == 1 && vals[0].toString().equals(""))) {
+            return true;
+        } else {
+	    return false;
+        }
+    }
+}


### PR DESCRIPTION
Config example (from uportal-war/src/main/resources/properties/groups/PAGSGroupStoreConfig.xml) : 
        <test>
          <attribute-name>mailHost</attribute-name>
          <tester-class>fr.runn.groups.pags.testers.MissingTester</tester-class>
          <test-value>dummy</test-value>
        </test>
[the test-value is required but not used by the MissingTester]
