### PR TITLE
pom.xml : default env is now esup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
          | character.  If you want to override the default environment.name by 
          | invoking Maven directly, you will have to append a period yourself.
          +-->
-        <env>local</env>
+        <env>esup</env>
         <filters.file>filters/${env}.properties</filters.file>
     
         <!-- WAR Dependency Version Properties -->


### PR DESCRIPTION
Pull-Request faisant suite à cette discussion sur le pull-request #14 : 
https://github.com/EsupPortail/esup-uportal/pull/14#r898539 
Vu que le env par défaut via ANT est esup (et non plus local), je propose que le env maven par défaut soit également esup (et non plus local).
