### PR TITLE
Define a default administrator in filters/esup.properties

### DIFF
--- a/filters/esup.properties
+++ b/filters/esup.properties
@@ -79,8 +79,15 @@ environment.build.log.size=1024
 environment.build.log.level=INFO
  
 # Esup 
-# NOT USE NOW
+# Logical name to distinguish app server in logs in load-balanced systems
 environment.build.host.logicalName=esup1
+
+# Portal Administrators
+# users with attribute "adminEsupAattribute" equal to "adminEsupValue" (ignore case) are members of "Portal Administrators" group
+# See bean "uPortalLdapAttributeSource" in uportal-war\\src\\main\\resources\\properties\\contexts\\personDirectoryContext.xml
+# for a list of attributes
+environment.build.adminEsupAattribute=uid
+environment.build.adminEsupValue=bibi
 
 environment.build.xsl.debug=ERROR
 environment.build.xsl.cache=

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -617,6 +617,7 @@
                     <include>properties/security.properties</include>
                     <include>properties/contexts/userContext.xml</include>
                     <include>properties/contexts/ldapContext.xml</include>
+                    <include>properties/groups/PAGSGroupStoreConfig.xml</include>
                     <include>properties/contexts/personDirectoryContext.xml</include>
                     <include>properties/i18n/*.properties</include>
                 </includes>

--- a/uportal-war/src/main/data/quickstart_fr_entities/fragment-definition/admin-lo.fragment-definition.xml
+++ b/uportal-war/src/main/data/quickstart_fr_entities/fragment-definition/admin-lo.fragment-definition.xml
@@ -23,7 +23,7 @@
   <dlm:fragment name="Admin" ownerID="admin-lo" precedence="50">
     <dlm:audience evaluatorFactory="org.jasig.portal.layout.dlm.providers.GroupMembershipEvaluatorFactory">
       <paren mode="OR">     
-        <attribute mode="memberOf" name="Portal Administrators"/>
+        <attribute mode="deepMemberOf" name="Portal Administrators"/>
         <attribute mode="memberOf" name="Portal Developers"/>
       </paren>
     </dlm:audience>

--- a/uportal-war/src/main/data/quickstart_fr_entities/group_membership/Portal_Administrators.group-membership.xml
+++ b/uportal-war/src/main/data/quickstart_fr_entities/group_membership/Portal_Administrators.group-membership.xml
@@ -25,6 +25,7 @@
   <creator>system</creator>
   <description>Administrateurs du portail</description>
   <children>
+    <group>Administrateurs ENT</group>
     <literal>admin</literal>
     <literal>admin-lo</literal>
   </children>

--- a/uportal-war/src/main/resources/properties/groups/PAGSGroupStoreConfig.xml
+++ b/uportal-war/src/main/resources/properties/groups/PAGSGroupStoreConfig.xml
@@ -99,6 +99,23 @@
     </selection-test>
   </group>
   
+  <!--==================== Administrateur portail par defaut ====================-->
+  
+  <group>
+    <group-key>adminEsup</group-key>
+    <group-name>Administrateurs ENT</group-name>
+    <group-description>Administrateurs du portail esup-portail</group-description>
+    <selection-test>
+      <test-group>
+        <test>
+          <attribute-name>${environment.build.adminEsupAattribute}</attribute-name>
+          <tester-class>org.jasig.portal.groups.pags.testers.StringEqualsIgnoreCaseTester</tester-class>
+          <test-value>${environment.build.adminEsupValue}</test-value>
+        </test>
+      </test-group>
+    </selection-test>
+  </group>
+  
   <!--==================== Other Examples ====================-->
 
 


### PR DESCRIPTION
Define a default administrator in filters/esup.properties, which can be used to log in with CAS after "ant initportal"
