### PR TITLE
add feature hide.from.desktop, similar to hide.from.mobile

### DIFF
--- a/uportal-war/src/main/resources/layout/structure/columns/columns.xsl
+++ b/uportal-war/src/main/resources/layout/structure/columns/columns.xsl
@@ -284,6 +284,9 @@
 </xsl:template>
 
 <xsl:template match="channel">
+  <!-- esup : add test hide from desktop-->
+<xsl:if test="not(parameter[@name='hideFromDesktop']/@value = 'true')">
+<!-- esup : end add test hide from desktop-->
   <xsl:choose>
     <xsl:when test="$userImpersonating = 'true' and parameter[@name='blockImpersonation']/@value = 'true'">
         <blocked-channel>
@@ -295,6 +298,9 @@
       <xsl:copy-of select="."/>
     </xsl:otherwise>
   </xsl:choose>
+<!-- esup : add test hide from desktop-->
+</xsl:if>
+<!-- esup : end fin uvhc-->
 </xsl:template>
 
 <xsl:template match="parameter">

--- a/uportal-war/src/main/resources/layout/theme/universality/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/navigation.xsl
@@ -401,6 +401,10 @@
           	<xsl:when test="$CONTEXT='flyout'">
             
               <xsl:for-each select="tabChannel">
+					<!-- esup : add test hide from desktop -->
+					<xsl:if test="not(@hideFromDesktop='true')">
+						<!-- esup : end test hide from desktop -->
+			
                 <xsl:variable name="SUBNAV_POSITION"> <!-- Determine the position of the navigation option within the whole navigation list and add css hooks for the first and last positions. -->
                   <xsl:choose>
                     <xsl:when test="position()=1 and position()=last()">single</xsl:when>
@@ -424,12 +428,18 @@
                       <span class="portal-subnav-label"><xsl:value-of select="@title"/></span>
                   </a>
                 </li>
+						<!-- esup : add test hide from desktop -->
+					</xsl:if>
+					<!-- esup : end add test hide from desktop -->
               </xsl:for-each>
               
             </xsl:when>
             <xsl:otherwise>
             	
               <xsl:for-each select="//navigation/tab[@activeTab='true']/tabChannel">
+			<!-- esup : add test hide from desktop -->
+			<xsl:if test="not(@hideFromDesktop='true')">
+				<!-- esup : end test hide from desktop -->
                 <xsl:variable name="SUBNAV_POSITION"> <!-- Determine the position of the navigation option within the whole navigation list and add css hooks for the first and last positions. -->
                   <xsl:choose>
                     <xsl:when test="position()=1 and position()=last()">single</xsl:when>
@@ -453,6 +463,9 @@
                     <span class="portal-subnav-label"><xsl:value-of select="@title"/></span>
                   </a>
                 </li>
+			<!-- esup : add test hide from desktop -->
+			</xsl:if>
+			<!-- esup : end add test hide from desktop -->
               </xsl:for-each>
               
             </xsl:otherwise>

--- a/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
+++ b/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
@@ -83,6 +83,15 @@
             </single-choice-parameter-input>
         </parameter>
     
+        <parameter>
+            <name>hideFromDesktop</name>
+            <label>hide.in.desktop.theme</label>
+            <single-choice-parameter-input display="select">
+                <default>false</default>
+                <option value="false" label="false"/>
+                <option value="true" label="true"/>
+            </single-choice-parameter-input>
+        </parameter>
         
         <parameter>
             <name>blockImpersonation</name>

--- a/uportal-war/src/main/resources/properties/i18n/Messages.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages.properties
@@ -242,6 +242,7 @@ help=Help
 hidden.in.impersonation.view=This portlet has been disabled during identity swap.
 hide.in.impersonation.view=Hide portlet during impersonation
 hide.in.mobile.theme=Hide in mobile theme
+hide.in.desktop.theme=Hide in desktop theme
 hit=hit
 hits=hits
 home=Home

--- a/uportal-war/src/main/resources/properties/i18n/Messages_fr.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages_fr.properties
@@ -242,6 +242,7 @@ help=Aide
 hidden.in.impersonation.view=Cette portlet a \u00e9t\u00e9 d\u00e9sactiv\u00e9e le temps de l''appropriation de l''identit\u00e9-utilisateur
 hide.in.impersonation.view=Cacher cette portlet durant l''appropriation de l''identit\u00e9-utilisateur
 hide.in.mobile.theme=Cacher dans la "vue" mobile
+hide.in.desktop.theme=Cacher dans la "vue" desktop
 hit=atteindre
 hits=succ\u00e8s
 home=Accueil


### PR DESCRIPTION
gives the possibility to display a portlet only on mobiles

remplace https://github.com/EsupPortail/esup-uportal/pull/29 :
- éviter la ré-indentation sur navigation.xsl
- ajouter un message lisible pour "hide.in.desktop.theme" (j'ai testé, je n'ai pas eu de pb)
