### PR TITLE
6 - logs (2) => Anticipation correction 4.0.10

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/log4j.properties
+++ b/uportal-war/src/main/webapp/WEB-INF/log4j.properties
@@ -86,14 +86,14 @@ log4j.additivity.org.hibernate.stat.Statistics=false
 #
 log4j.appender.R=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.R.File=${environment.build.log.logfileDirectory}/${environment.build.log.logfileName}
-log4j.appender.R.DatePattern=${environment.build.log.rollingLogFileDatePattern}
+log4j.appender.R.DatePattern='.'${environment.build.log.rollingLogFileDatePattern}
 log4j.appender.R.Encoding=UTF-8
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
 log4j.appender.R.layout.ConversionPattern=${environment.build.log.layoutConversionPattern}
 
 log4j.appender.E=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.E.File=${environment.build.log.logfileDirectory}/uPortal-events.log
-log4j.appender.E.DatePattern=${environment.build.log.rollingLogFileDatePattern}
+log4j.appender.E.DatePattern='.'${environment.build.log.rollingLogFileDatePattern}
 log4j.appender.E.Encoding=UTF-8
 log4j.appender.E.layout=org.apache.log4j.PatternLayout
 log4j.appender.E.layout.ConversionPattern=${environment.build.log.layoutConversionPattern}


### PR DESCRIPTION
Demande ESUP : 
https://www.esup-portail.org/pages/viewpage.action?pageId=258605058&focusedCommentId=266174477#comment-266174477

Le fichier a moitié corrigé en 4.0.10 : 
https://github.com/Jasig/uPortal/blob/uportal-4.0.10/uportal-war/src/main/webapp/WEB-INF/log4j.properties
(à moitié parce que seul le logger R est corrigé. E reste sans le '.')
