### PR TITLE
Internationalisation du footer via fichier externe

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/universality/messages.xml
+++ b/uportal-war/src/main/resources/layout/theme/universality/messages.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" ?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<theme-messages>
+    <!-- 
+     | institution specific messages are keyed off of the INSTITUTION XSL variable in universality.xsl They allow
+     | different messages for a locale based on the currently selected skin.
+     |
+     | The institution specific token is NOT an override, these are in-addition to the tokens defined without an
+     | institution attribute. Therefore if a token is defined as institution specific it must be defined for all
+     | possible institutions.
+     +-->
+    <tokens xml:lang="en-US" institution="university">
+    </tokens>
+    <tokens xml:lang="en-US" institution="ivy">
+    </tokens>
+    <tokens xml:lang="en-US" institution="uportal">
+    </tokens>
+    
+    <tokens xml:lang="en-US">
+        <!-- Footer -->
+		<token name="UPORTAL_POWERED">Powered by uPortal</token>
+		<token name="OPEN_SOURCE">, an open-source project by </token>
+		<token name="SESSION_KEY">Session Key:</token>
+		<token name="UPORTAL_LICENSED"> is licensed under the </token>
+		<token name="LICENSE_APPROVEMENT"> as approved by the Open Source Initiative (OSI), an </token>
+		<token name="OSI">OSI-certified</token>
+		<token name="OPEN_LICENSE"> ("open") and </token>
+		<token name="GNU">Gnu/FSF-recognized</token>
+		<token name="FREE_LICENSE"> ("free") license.</token>
+		<token name="ICON_SET">Silk icon set 1.3</token>
+		<token name="ICON_SET_AUTHOR"> courtesy of Mark James.</token>
+		
+		
+    </tokens>
+    
+	<tokens xml:lang="fr-FR">
+		<!-- Footer -->
+		<token name="UPORTAL_POWERED">Site conçu via uPortal</token>
+		<token name="OPEN_SOURCE">, un projet open-source de </token>
+		<token name="SESSION_KEY">Clé de Session:</token>
+		<token name="UPORTAL_LICENSED"> est sous license </token>
+		<token name="LICENSE_APPROVEMENT"> approuvée par l'Open Source Initiative (OSI), une license </token>
+		<token name="OSI">certifiée OSI</token>
+		<token name="OPEN_LICENSE"> ("ouverte") et </token>
+		<token name="GNU">reconnue par la license Gnu/FSF</token>
+		<token name="FREE_LICENSE"> ("libre").</token>
+		<token name="ICON_SET">Set d'icônes Silk 1.3</token>
+		<token name="ICON_SET_AUTHOR"> avec la permission de Mark James.</token>
+	</tokens>
+</theme-messages>    
+    

--- a/uportal-war/src/main/resources/layout/theme/universality/universality.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/universality.xsl
@@ -172,6 +172,7 @@
    | GREEN
    | Locatlization Settings can be used to change the localization of the theme.
   -->
+	<xsl:param name="MESSAGE_DOC_URL">messages.xml</xsl:param> <!-- Name of the localization file. -->
 	<xsl:param name="USER_LANG">en</xsl:param> <!-- Sets the default user language. -->
   
   
@@ -225,7 +226,7 @@
         <xsl:otherwise>false</xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  
+  <xsl:variable name="TOKEN" select="document($MESSAGE_DOC_URL)/theme-messages/tokens[lang($USER_LANG) and (@institution=$INSTITUTION or not(@institution))]/token"/> <!-- Tells the theme how to find appropriate localized token. -->  
   
   <!-- ****** INSTITUTION SETTINGS ****** -->
   <!-- 
@@ -951,11 +952,11 @@
 	      <!-- uPortal Product Version -->
 	      <div id="portalProductAndVersion">
 	        <p>
-                <a href="http://www.jasig.org/uportal" title="Powered by uPortal ${UP_VERSION}" target="_blank">Powered by uPortal <xsl:value-of select="$UP_VERSION"/></a>, an open-source project by <a href="http://www.jasig.org" title="Jasig.org - Open for Higher Education">Jasig</a> - <span><xsl:value-of select="$SERVER_NAME"/></span>
+                <a href="http://www.jasig.org/uportal" title="{$TOKEN[@name='UPORTAL_POWERED']} ${UP_VERSION}" target="_blank"><xsl:value-of select="$TOKEN[@name='UPORTAL_POWERED']"/> <xsl:value-of select="$UP_VERSION"/></a><xsl:value-of select="$TOKEN[@name='OPEN_SOURCE']"/> <a href="http://www.jasig.org" title="Jasig.org - Open for Higher Education">Jasig</a> - <span><xsl:value-of select="$SERVER_NAME"/></span>
                 <xsl:if test="$AUTHENTICATED='true'">
                     <br/>
                     <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
-                    <span>Session Key: </span><span><xsl:value-of select="$STATS_SESSION_ID"/></span>
+                    <span><xsl:value-of select="$TOKEN[@name='SESSION_KEY']"/> </span><span><xsl:value-of select="$STATS_SESSION_ID"/></span>
                     <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
                 </xsl:if>
             </p>
@@ -964,12 +965,12 @@
       
 	      <!-- Copyright -->
 	      <div id="portalCopyright">
-	        <p><a href="http://www.jasig.org/uportal/about/license" title="uPortal" target="_blank">uPortal</a> is licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" title="Apache License, Version 2.0" target="_blank">Apache License, Version 2.0</a> as approved by the Open Source Initiative (OSI), an <a href="http://www.opensource.org/docs/osd" title="OSI-certified" target="_blank">OSI-certified</a> ("open") and <a href="http://www.gnu.org/licenses/license-list.html" title="Gnu/FSF-recognized" target="_blank">Gnu/FSF-recognized</a> ("free") license.</p>
+	        <p><a href="http://www.jasig.org/uportal/about/license" title="uPortal" target="_blank">uPortal</a> <xsl:value-of select="$TOKEN[@name='UPORTAL_LICENSED']"/> <a href="http://www.apache.org/licenses/LICENSE-2.0" title="Apache License, Version 2.0" target="_blank">Apache License, Version 2.0</a> <xsl:value-of select="$TOKEN[@name='LICENSE_APPROVEMENT']"/> <a href="http://www.opensource.org/docs/osd" title="{$TOKEN[@name='OSI']}" target="_blank"><xsl:value-of select="$TOKEN[@name='OSI']"/></a> <xsl:value-of select="$TOKEN[@name='OPEN_LICENSE']"/> <a href="http://www.gnu.org/licenses/license-list.html" title="{$TOKEN[@name='GNU']}" target="_blank"><xsl:value-of select="$TOKEN[@name='GNU']"/></a> <xsl:value-of select="$TOKEN[@name='FREE_LICENSE']"/></p>
 	      </div>
       
 	      <!-- Icon Set Attribution -->
 	      <div id="silkIconsAttribution">
-	        <p><a href="http://www.famfamfam.com/lab/icons/silk/" title="Silk icon set 1.3" target="_blank">Silk icon set 1.3</a> courtesy of Mark James.</p>
+	        <p><a href="http://www.famfamfam.com/lab/icons/silk/" title="{$TOKEN[@name='ICON_SET']}" target="_blank"><xsl:value-of select="$TOKEN[@name='ICON_SET']"/></a> <xsl:value-of select="$TOKEN[@name='ICON_SET_AUTHOR']"/></p>
 	        <!-- Silk icon set 1.3 by Mark James [ http://www.famfamfam.com/lab/icons/silk/ ], which is licensed under a Creative Commons Attribution 2.5 License. [ http://creativecommons.org/licenses/by/2.5/ ].  This icon set is free for use under the CCA 2.5 license, so long as there is a link back to the author's site.  If the Silk icons are used, this reference must be present in the markup, though not necessarily visible in the rendered page.  If you don't want the statement to visibly render in the page, use CSS to make it invisible. -->
 	      </div>
     	</div>


### PR DESCRIPTION
Refonte de la traduction du footer suite à conf-call du 25/02 avec :
- création d'un fichier "messages.xml" permettant l'externalisation des messages du footer et l'internationalisation de ceux-ci.
- et réécriture du fichier XSL du thème universality pour importer ce fichier de messages et utiliser les messages contenus dans celui-ci.
