### PR TITLE
Refonte Traduction Footer avec fichiers Properties

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/universality/universality.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/universality.xsl
@@ -172,7 +172,7 @@
    | GREEN
    | Locatlization Settings can be used to change the localization of the theme.
   -->
-	<xsl:param name="USER_LANG">en</xsl:param> <!-- Sets the default user language. -->
+	<xsl:param name="USER_LANG">fr</xsl:param> <!-- Sets the default user language. -->
   
   
   <!-- ****** PORTAL SETTINGS ****** -->
@@ -951,11 +951,11 @@
 	      <!-- uPortal Product Version -->
 	      <div id="portalProductAndVersion">
 	        <p>
-                <a href="http://www.jasig.org/uportal" title="Powered by uPortal ${UP_VERSION}" target="_blank">Powered by uPortal <xsl:value-of select="$UP_VERSION"/></a>, an open-source project by <a href="http://www.jasig.org" title="Jasig.org - Open for Higher Education">Jasig</a> - <span><xsl:value-of select="$SERVER_NAME"/></span>
+                <a href="http://www.jasig.org/uportal" title="{upMsg:getMessage('footer.uportal.powered.by', $USER_LANG)} {$UP_VERSION}" target="_blank"><xsl:value-of select="upMsg:getMessage('footer.uportal.powered.by', $USER_LANG)"/><xsl:value-of select="$UP_VERSION"/></a><xsl:value-of select="upMsg:getMessage('footer.open.source', $USER_LANG)"/><a href="http://www.jasig.org" title="Jasig.org - Open for Higher Education">Jasig</a> - <span><xsl:value-of select="$SERVER_NAME"/></span>
                 <xsl:if test="$AUTHENTICATED='true'">
                     <br/>
                     <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
-                    <span>Session Key: </span><span><xsl:value-of select="$STATS_SESSION_ID"/></span>
+                    <span><xsl:value-of select="upMsg:getMessage('footer.session.key', $USER_LANG)"/></span><span><xsl:value-of select="$STATS_SESSION_ID"/></span>
                     <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
                 </xsl:if>
             </p>
@@ -964,12 +964,12 @@
       
 	      <!-- Copyright -->
 	      <div id="portalCopyright">
-	        <p><a href="http://www.jasig.org/uportal/about/license" title="uPortal" target="_blank">uPortal</a> is licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" title="Apache License, Version 2.0" target="_blank">Apache License, Version 2.0</a> as approved by the Open Source Initiative (OSI), an <a href="http://www.opensource.org/docs/osd" title="OSI-certified" target="_blank">OSI-certified</a> ("open") and <a href="http://www.gnu.org/licenses/license-list.html" title="Gnu/FSF-recognized" target="_blank">Gnu/FSF-recognized</a> ("free") license.</p>
+	        <p><a href="http://www.jasig.org/uportal/about/license" title="uPortal" target="_blank">uPortal </a><xsl:value-of select="upMsg:getMessage('footer.uportal.licensed', $USER_LANG)"/><a href="http://www.apache.org/licenses/LICENSE-2.0" title="Apache License, Version 2.0" target="_blank">Apache License, Version 2.0 </a> <xsl:value-of select="upMsg:getMessage('footer.license.approvment', $USER_LANG)"/><a href="http://www.opensource.org/docs/osd" title="{upMsg:getMessage('footer.osi', $USER_LANG)}" target="_blank"><xsl:value-of select="upMsg:getMessage('footer.osi', $USER_LANG)"/> </a><xsl:value-of select="upMsg:getMessage('footer.open.license', $USER_LANG)"/><a href="http://www.gnu.org/licenses/license-list.html" title="{upMsg:getMessage('footer.gnu', $USER_LANG)}" target="_blank"><xsl:value-of select="upMsg:getMessage('footer.gnu', $USER_LANG)"/> </a><xsl:value-of select="upMsg:getMessage('footer.free.license', $USER_LANG)"/></p>
 	      </div>
       
 	      <!-- Icon Set Attribution -->
 	      <div id="silkIconsAttribution">
-	        <p><a href="http://www.famfamfam.com/lab/icons/silk/" title="Silk icon set 1.3" target="_blank">Silk icon set 1.3</a> courtesy of Mark James.</p>
+	        <p><a href="http://www.famfamfam.com/lab/icons/silk/" title="{upMsg:getMessage('footer.icon.set', $USER_LANG)}" target="_blank"><xsl:value-of select="upMsg:getMessage('footer.icon.set', $USER_LANG)"/> </a><xsl:value-of select="upMsg:getMessage('footer.icon.set.author', $USER_LANG)"/></p>
 	        <!-- Silk icon set 1.3 by Mark James [ http://www.famfamfam.com/lab/icons/silk/ ], which is licensed under a Creative Commons Attribution 2.5 License. [ http://creativecommons.org/licenses/by/2.5/ ].  This icon set is free for use under the CCA 2.5 license, so long as there is a link back to the author's site.  If the Silk icons are used, this reference must be present in the markup, though not necessarily visible in the rendered page.  If you don't want the statement to visibly render in the page, use CSS to make it invisible. -->
 	      </div>
     	</div>

--- a/uportal-war/src/main/resources/properties/i18n/Messages.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages.properties
@@ -573,3 +573,16 @@ report.list=Report List
 generate.new.report=Generate a new {0} Report
 # The placeholder $0 is used by Javascript to substitute a parameter into
 report.titleWithSingularFields={0} - $0
+
+# Traduction du footer du portail pour le thème "universality"
+footer.uportal.powered.by=Powered by uPortal 
+footer.open.source=, an open-source project by 
+footer.session.key=Session Key:
+footer.uportal.licensed=is licensed under the 
+footer.license.approvment=as approved by the Open Source Initiative (OSI), an 
+footer.osi=OSI-certified 
+footer.open.license=("open") and 
+footer.gnu=Gnu/FSF-recognized 
+footer.free.license=("free") license.
+footer.icon.set=Silk icon set 1.3 
+footer.icon.set.author=courtesy of Mark James.

--- a/uportal-war/src/main/resources/properties/i18n/Messages_fr.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages_fr.properties
@@ -30,7 +30,7 @@ add.attribute=Ajouter un attribut
 add.columns=Ajouter des colonnes
 add.content=Ajouter un contenu
 add.message=Ajouter un message
-add.package.instruction=Ajouter un package cr\u00e9e un nouvel onglet dans lequel sont ins\u00e9r\u00e9s les diff\u00e9rents services qui le composent
+add.package.instruction=L''ajout d''un package cr\u00e9e un nouvel onglet dans lequel sont ins\u00e9r\u00e9s les diff\u00e9rents services qui le composent
 add.parameter=Ajouter un param\u00e8tre
 add.permission=Ajouter une autorisation
 add.portlets.to.this.column=Ajouter des portlets \u00e0 cette colonne
@@ -541,3 +541,16 @@ your.account.has.been.successfully.updated.your.changes.will.be.visible.upon.you
 your.password.has.been.updated.successfully=Votre mot de passe a bien \u00e9t\u00e9 mis \u00e0 jour
 your.selection=Votre s\u00e9lection
 your.selections=Vos s\u00e9lections
+
+# Traduction du footer du portail pour le thème "universality"
+footer.uportal.powered.by=Site con\u00e7u via uPortal 
+footer.open.source=, un projet open-source de 
+footer.session.key=Cl\u00e9 de Session:
+footer.uportal.licensed=est sous license 
+footer.license.approvment=approuv\u00e9e par l''Open Source Initiative (OSI), une license 
+footer.osi=certifi\u00e9e OSI 
+footer.open.license=("ouverte") et 
+footer.gnu=reconnue par la license Gnu/FSF 
+footer.free.license=("libre").
+footer.icon.set=Set d'ic\u00f4nes Silk 1.3 
+footer.icon.set.author=avec la permission de Mark James.


### PR DESCRIPTION
Refonte de la traduction du footer suite au commentaire de M. Guérin sur le PR 75. 
Désormais l'externalisation du footer est géré via les fichiers de properties existants de l'application (Messages_xx.properties).

Cela a impliqué une réécriture du fichier XSL du thème universality pour utiliser les propriétés définies dans les fichiers Messages_fr.properties et Messages.properties (pour la langue anglaise).
