### PR TITLE
Problème de saisie de message i18n dans la portlet jasig-widget-portlets

### DIFF
--- a/uportal-portlets-overlay/jasig-widget-portlets/src/main/resources/messages_fr.properties
+++ b/uportal-portlets-overlay/jasig-widget-portlets/src/main/resources/messages_fr.properties
@@ -24,8 +24,8 @@ alertAdmin.button.unspecified = Activer maintenant
 alertAdmin.disabled           = d\u00E9sactiv\u00E9e
 alertAdmin.enabled            = activ\u00E9e
 alertAdmin.note               = Note : vous devez rafra\u00EEchir la page ou cliquer sur un autre onglet pour voir les modifications effectu\u00E9es.
-alertAdmin.text               = La portlet de messages d''urgence est actuellement
-alertAdmin.title              = Administration de la portlet de messages d''urgence
+alertAdmin.text               = La portlet de messages d'urgence est actuellement
+alertAdmin.title              = Administration de la portlet de messages d'urgence
 alertAdmin.unspecified        = Non sp\u00E9cifi\u00E9
 
 language.ar    = Arabic


### PR DESCRIPTION
Correction de l'affichage de deux apostrophes dans la portlet nommée "Gestion des messages d'alerte"
