### PR TITLE
Change log level of grouperGroupStore info into debug to avoid to list all group's name in in...

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/groups/smartldap/SimpleContextMapper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/smartldap/SimpleContextMapper.java
@@ -15,36 +15,36 @@ import org.jasig.portal.security.IPerson;
 
 public class SimpleContextMapper implements ContextMapper{
 
-  private static final String GROUP_DESCRIPTION = 
+  private static final String GROUP_DESCRIPTION =
 			"This group was pulled from the directory server.";
 
 	/**
-	 * Name of the LDAP attribute on a group that tells you 
+	 * Name of the LDAP attribute on a group that tells you
 	 * its key (normally 'dn').
 	 */
-	private String keyAttributeName = null; 
+	private String keyAttributeName = null;
 
 	/**
-	 * Name of the LDAP attribute on a group that tells you 
+	 * Name of the LDAP attribute on a group that tells you
 	 * the name of the group.
 	 */
-	private String groupNameAttributeName = null; 
+	private String groupNameAttributeName = null;
 
 	/**
-	 * Name of the LDAP attribute on a group that tells you 
+	 * Name of the LDAP attribute on a group that tells you
 	 * who its children are.
 	 */
-	private String membershipAttributeName = null; 
+	private String membershipAttributeName = null;
 
 	private final Log log = LogFactory.getLog(getClass());
 
 	/*
 	 * Public API.
-	 */	
+	 */
 
 	public Object mapFromContext(Object ctx) {
 		DirContextAdapter context = (DirContextAdapter) ctx;
-		
+
 		// Assertions.
 		if (groupNameAttributeName == null) {
 			String msg = "The property 'groupNameAttributeName' must be set.";
@@ -55,17 +55,17 @@ public class SimpleContextMapper implements ContextMapper{
 			throw new IllegalStateException(msg);
 		}
 
-		if (log.isInfoEnabled()) {
-			String msg = "SimpleContextMapper.mapFromContext() :: settings:  groupNameAttributeName='" 
-					+ groupNameAttributeName + "', membershipAttributeName='" 
+		if (log.isDebugEnabled()) {
+			String msg = "SimpleContextMapper.mapFromContext() :: settings:  groupNameAttributeName='"
+					+ groupNameAttributeName + "', membershipAttributeName='"
 					+ membershipAttributeName + "'";
-			log.info(msg);
+			log.debug(msg);
 		}
 
 		LdapRecord rslt;
 
 		try {
-            
+
 			String key ;
 			if (keyAttributeName == null) {
 			    key = (String) context.getDn().toString();
@@ -73,14 +73,14 @@ public class SimpleContextMapper implements ContextMapper{
 			    key = (String) context.getStringAttribute(keyAttributeName);
 			}
 			String groupName = (String) context.getStringAttribute(groupNameAttributeName);
-    
+
 			IEntityGroup g = new EntityTestingGroupImpl(key, IPerson.class);
 			g.setCreatorID("System");
 			g.setName(groupName);
 			g.setDescription(GROUP_DESCRIPTION);
-			
+
 			List<String> membership = new LinkedList<String>(Arrays.asList(context.getStringAttributes(membershipAttributeName)));
-			
+
 			rslt = new LdapRecord(g, membership);
 
 			if (log.isInfoEnabled()) {
@@ -102,7 +102,7 @@ public class SimpleContextMapper implements ContextMapper{
 			throw new RuntimeException(msg, t);
 		}
 
-		return rslt;		
+		return rslt;
 
 	}
 

--- a/uportal-war/src/main/resources/org/jasig/portal/groups/smartldap/init.crn
+++ b/uportal-war/src/main/resources/org/jasig/portal/groups/smartldap/init.crn
@@ -117,7 +117,7 @@
             
         </script>
         <subtasks>
-            <log logger-name="org.jasig.portal.groups.smartldap.init" >SmartLdap adding record for group:  ${groovy(record.getGroup().getName())}</log>
+            <log level="debug" logger-name="org.jasig.portal.groups.smartldap.init" >SmartLdap adding record for group:  ${groovy(record.getGroup().getName())}</log>
             <if test="${groovy(isNew &amp;&amp; resolveMemberGroups)}">
                 <for-each items="${resolveDnList}" attribute-name="resolveDn">
                     <!-- Be sure we don't waste a lot of time with unnecessary queries --> 


### PR DESCRIPTION
...fo log, it's better in debug level, more we have a summary in info level of the smartLdapGroupStore task loading and it gives the number of groups loaded.
