### PR TITLE
add portlet esup-portlet-monitor in the admin fragment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,8 @@
         <SimpleContentPortlet.version>1.0.2</SimpleContentPortlet.version>
         <WeatherPortlet.version>1.0.9</WeatherPortlet.version> <!-- ESUP: si version superieure a 1.0.9, ne pas oublier de faire un revert sur le commit "WeatherPortlet i18n: patch edit.jsp : WPT-44 & WPT-55 jasig/WeatherPortlet" -->
         <WebProxyPortlet.version>1.1.7</WebProxyPortlet.version>
+	<!-- portlet ESUP -->
+	<esup-portlet-monitor.version>0.1</esup-portlet-monitor.version>
 
         <!-- Project Dependency Version Properties -->
         <aopalliance.version>1.0</aopalliance.version>

--- a/uportal-ear/pom.xml
+++ b/uportal-ear/pom.xml
@@ -120,7 +120,14 @@
             <version>${project.version}</version>
             <type>war</type>
         </dependency>
-        
+       
+	<dependency>
+            <groupId>org.jasig.portal.portlets-overlay</groupId>
+            <artifactId>portlet-monitor</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+ 
         <dependency>
             <groupId>javax.ccpp</groupId>
             <artifactId>ccpp</artifactId>

--- a/uportal-portlets-overlay/pom.xml
+++ b/uportal-portlets-overlay/pom.xml
@@ -29,6 +29,7 @@
         <module>SimpleContentPortlet</module>
         <module>WeatherPortlet</module>
         <module>WebProxyPortlet</module>
+        <module>portlet-monitor</module>
     </modules>
 
     <build>

--- a/uportal-portlets-overlay/portlet-monitor/.gitignore
+++ b/uportal-portlets-overlay/portlet-monitor/.gitignore
@@ -1,0 +1,5 @@
+/.settings
+/.project
+/.classpath
+/bin
+/target

--- a/uportal-portlets-overlay/portlet-monitor/pom.xml
+++ b/uportal-portlets-overlay/portlet-monitor/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.jasig.portal.portlets-overlay</groupId>
+        <artifactId>uportal-portlets-overlay</artifactId>
+        <version>4.0.12-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>portlet-monitor</artifactId>
+    <packaging>war</packaging>
+
+    <name>esup-monitor</name>
+    <description>Overlay on esup-portlet-monitor.</description>
+
+    <dependencies>
+        <!-- ===== Compile Time Dependencies ============================== -->
+        <dependency>
+        	<groupId>org.esup.portail</groupId>
+		    <artifactId>portlet-monitor</artifactId>
+		    <version>${esup-portlet-monitor.version}</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <filters>
+            <filter>../../${filters.file}</filter>
+        </filters>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <filters>
+                        <filter>${basedir}/../../${filters.file}</filter>
+                    </filters>
+                    <dependentWarExcludes>
+                        WEB-INF/lib/hsqldb-*.jar
+                    </dependentWarExcludes>
+                    <webResources>
+                        <resource>
+                            <directory>${basedir}/src/main/webapp/WEB-INF</directory>
+                            <targetPath>WEB-INF</targetPath>
+                            <filtering>true</filtering>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+           <plugin>
+                <groupId>org.apache.portals.pluto</groupId>
+                <artifactId>maven-pluto-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/uportal-portlets-overlay/portlet-monitor/src/main/resources/config.properties
+++ b/uportal-portlets-overlay/portlet-monitor/src/main/resources/config.properties
@@ -1,0 +1,3 @@
+auth.bean=OfflineFixedUserAuthenticationService
+cas.url=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}
+auth.portal.uidAttribute=${environment.build.ldap.uidAttr}

--- a/uportal-portlets-overlay/portlet-monitor/src/main/resources/listeServers.xml
+++ b/uportal-portlets-overlay/portlet-monitor/src/main/resources/listeServers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config>
+	<server name="server1" url="${environment.build.uportal.protocol}://${environment.build.real.uportal.server}${environment.build.real.uportal.context}/EsupMonitor" />
+</config>

--- a/uportal-portlets-overlay/portlet-monitor/src/main/resources/log4j.properties
+++ b/uportal-portlets-overlay/portlet-monitor/src/main/resources/log4j.properties
@@ -1,0 +1,89 @@
+#
+# Licensed to Jasig under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Jasig licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a
+# copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+###########################################################################
+# Log file variables, such as "{environment.build.log.rootLevel}" are defined
+# by properties in the uPortal/filters directory.  See the Building
+# and Deploying uPortal section of the uPortal manual
+
+###########################################################################
+# Adjust logging level to appropriate level of logging.  Once
+# everything is running, using WARN or ERROR will turn off
+# tons of debug messages.
+#
+log4j.rootCategory=${environment.build.log.rootLevel}, R
+#log4j.category.edu.wisc.my.webproxy=DEBUG, R
+#log4j.additivity.edu.wisc.my.webproxy=false
+
+
+###########################################################################
+# Setup a rolling file appender
+#
+log4j.appender.R=org.apache.log4j.DailyRollingFileAppender
+
+###########################################################################
+# Uncomment the next line to have messages go to stdout (System.out)
+#
+#log4j.appender.R=org.apache.log4j.ConsoleAppender
+
+
+# This is the path to the log file. It's usually set to something like
+# c:\\portal\\logs\\portal.log or /opt/portal/logs/portal.log
+# Relative file names will be relative to the directory specified by the
+# user.dir System property.
+# WARNING: ALL SLASHES MUST BE FORWARD SLASHES OR ESCAPED BACK SLASHES!!!
+#
+log4j.appender.R.File=${environment.build.log.logfileDirectory}/portlet-monitor-springmvc-portlet.log
+
+# This tells log4j what type of encoding to use
+#
+log4j.appender.R.Encoding=UTF-8
+
+# This tells log4j to use PatternLayout for log file formatting
+#
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+
+# Pattern used during debugging
+#
+#log4j.appender.R.layout.ConversionPattern=%5p [%t] %d{MMM/dd HH:mm:ss,SSS} %c{2}.[%x] (%F:%L) - %m%n
+
+# Pattern that should be used when speed is important (it doesn't provide location info)
+#
+log4j.appender.R.layout.ConversionPattern=${environment.build.log.layoutConversionPattern}
+
+# Log file rolling frequency
+log4j.appender.R.DatePattern='.'${environment.build.log.rollingLogFileDatePattern}
+
+# Pattern for performing hourly log rolling, defaults to '.'yyyy-MM-dd
+#
+#log4j.appender.R.DatePattern='.'yyyy-MM-dd-HH
+
+###########################################################################
+# Setup a smtp appender
+#log4j.appender.mail=org.apache.log4j.net.SMTPAppender
+#defines how othen emails are send
+#log4j.appender.mail.BufferSize=1
+#log4j.appender.mail.SMTPHost=${esup.portlet-monitor-springmvc-portlet.smtpHost}
+#log4j.appender.mail.From=${esup.portlet-monitor-springmvc-portlet.log4jSmtpFrom}
+#log4j.appender.mail.To=${esup.portlet-monitor-springmvc-portlet.log4jSmtpTo}
+#log4j.appender.mail.Subject=[Error in portlet-monitor-springmvc-portlet]
+#log4j.appender.mail.threshold=error
+#log4j.appender.mail.layout=org.apache.log4j.PatternLayout
+#log4j.appender.mail.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/admin-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/admin-lo.fragment-layout.xml
@@ -44,6 +44,7 @@
         </structure-attribute>
         <channel fname="please-register" unremovable="false" hidden="false" immutable="false" ID="n11"/>
         <channel fname="emergency-alert-admin" unremovable="false" hidden="false" immutable="false" ID="n12"/>
+        <channel fname="monitor" unremovable="false" hidden="false" immutable="false" ID="n13"/>
       </folder>
     </folder>
   </folder>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/monitor.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/monitor.portlet-definition.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
+    <title>Monitoring des portails</title>
+    <name>Monitoring des portails</name>
+    <fname>monitor</fname>
+    <desc>Monitoring des portails</desc>
+    <type>Portlet</type>
+    <timeout>5000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/portlet-monitor</ns2:webAppName>
+        <ns2:portletName>esup-monitor</ns2:portletName>
+    </portlet-descriptor>
+    <category>uPortal</category>
+    <group>Portal Developers</group>
+    <group>Portal Administrators</group>
+    <parameter>
+        <name>alternate</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>blockImpersonation</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>disableDynamicTitle</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
+        <name>editable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasAbout</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasHelp</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hideFromDesktop</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hideFromMobile</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>highlight</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>showChrome</name>
+        <value>true</value>
+    </parameter>
+</portlet-definition>


### PR DESCRIPTION
Ajout du portlet esup-portlet-monitor dans les portlets overlay avec déploiement auto et mise à disposiition dans le fragment layout des admin.

Attention cela ne fonctionnera que si :
- ce PR https://github.com/EsupPortail/esup-portlet-monitor/pull/1 est intégré
- qu'un mvn deploy soit réalisé à la racine du projet sur un dépot maven
- que le dépôt utilisé soit dans les liste des repository du esup-uportal/pom.xml  (ce point restant à définir et n'étant pas poussé dans ce PR, car je n'ai pas de droit sur le nexus esup) 
