### PR TITLE
add iframe-autoheight-using-postMessage.js to handle dynamic-height iframes

### DIFF
--- a/uportal-war/src/main/webapp/media/skins/common/common_skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/common/common_skin.xml
@@ -25,4 +25,5 @@
  xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
   
   <js>javascript/uportal/up-ga.js</js>
+  <js>javascript/uportal/iframe-autoheight-using-postMessage.js</js>
 </resources>

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/iframe-autoheight-using-postMessage.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/iframe-autoheight-using-postMessage.js
@@ -1,0 +1,20 @@
+(function ($) {
+    var receiveIframeHeight = function(frameWindow, height) {
+        $("iframe").each(function () {
+            if (this.contentWindow === frameWindow) this.height = height;
+        });
+    };
+    var onmessage = function(e) {
+        if (typeof e.data === "string") {
+            var m = e.data.match(/^iframeHeight (\d+)$/);
+            if (m) receiveIframeHeight(e.source, parseInt(m[1]));
+        }
+    };
+
+    if (window.addEventListener) {  
+        window.addEventListener("message", onmessage, false);  
+    } else {  
+        window.attachEvent("onmessage", onmessage); // for IE
+    }
+})(jQuery);
+


### PR DESCRIPTION
As discussed in esup gt-development, iframe-autoheight-using-postMessage.js is a very simple js code
which handles message "iframeHeight XXX" sent by iframe to uportal using postMessage.

This allows an iframe to tell uportal its height to get rid of vertical scrollbars for the iframe.

 (see also http://prigaux.github.io/presentation-integration-iframe-ENT/ https://listes.esup-portail.org/sympa/arc/esup-utilisateurs/2012-04/msg00000.html )
